### PR TITLE
ci(test): run on `pull_request` not `pull_request_target`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
I think we changed it to `pull_request_target` because of Dependabot at some point, but that is no longer needed, plus we do not use dependabot any more. I do not see a reason why we should not be using the more restricted `pull_request` event for testing