### PR TITLE
fix: export types explicitly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,4 +14,4 @@ type Validate = (query: ReadonlyArray<string> | Readonly<string>) => ReadonlyArr
 export const schema: Schema
 export const validate: Validate
 
-export * from './schema'
+export type * from './schema'


### PR DESCRIPTION
### Before the change?

* When importing types into a TypeScript project, the latest release was causing a `Module '"@octokit/graphql-schema"' has no exported member '<name>'.` error.

```js
import type { Reaction } from '@octokit/graphql-schema'
```

This error was experienced in a TypeScript project with the following configuration:

- Node.js v21.6.2
- TypeScript 5.4.3
- TSConfig:

```json
{
  "$schema": "https://json.schemastore.org/tsconfig",
  "compilerOptions": {
    "baseUrl": "./",
    "declaration": true,
    "declarationMap": false,
    "esModuleInterop": true,
    "forceConsistentCasingInFileNames": true,
    "lib": ["ES2022"],
    "module": "NodeNext",
    "moduleResolution": "NodeNext",
    "newLine": "lf",
    "noImplicitAny": true,
    "noUnusedLocals": true,
    "noUnusedParameters": false,
    "pretty": true,
    "resolveJsonModule": true,
    "sourceMap": true,
    "strict": true,
    "strictNullChecks": true,
    "target": "ES2022",
    "verbatimModuleSyntax": true
  }
}
```

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* This attempts to resolve the error by explicitly importing and exporting types from `schema.d.ts` into `index.d.ts`

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

