### PR TITLE
fix: correct type export to use .d.ts extension

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,4 +14,4 @@ type Validate = (query: ReadonlyArray<string> | Readonly<string>) => ReadonlyArr
 export const schema: Schema
 export const validate: Validate
 
-export type * from './schema'
+export type * from './schema.d.ts'


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

Since v15 era, looks like related to #909
And for my case, this is not yet fixed in v15.4.1(#923)

I'm not an expert for this domain, but in my understanding, omitting extensions for `.d.ts` expect the related `.js`. Currently there is no `schema.js` in the package. https://github.com/microsoft/TypeScript/issues/48508#issuecomment-1098591002

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Cannot use the exported types, at least for `CheckSuite`, `Workflow`, `CheckRun`, `Commit`
* my use-case: https://github.com/kachick/wait-other-jobs/blob/2f486e6edf4772ae8aa7f4776c8ba6b079aef33e/src/github-api.ts#L3
* ![image](https://github.com/octokit/graphql-schema/assets/1180335/4a8313b8-7ef0-4641-8d65-2c51adb75c42)
* https://github.com/arethetypeswrong/arethetypeswrong.github.io display errors for ESM packaging 
![image](https://github.com/octokit/graphql-schema/assets/1180335/7fef0629-232f-465f-9c7e-5bb8560080e0)

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* ![image](https://github.com/octokit/graphql-schema/assets/1180335/a0d6ebef-66d8-4d91-b5aa-30b85f67be0a)
* ![image](https://github.com/octokit/graphql-schema/assets/1180335/eb149fb6-5668-46c9-836c-c72913471713)

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features) => Added in https://github.com/octokit/graphql-schema/pull/925
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

