### PR TITLE
ci(update): use app token instead of obsolete PAT

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,10 +17,15 @@ jobs:
       - run: npm run update
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.OCTOKIT_APP_ID }}
+          private-key: ${{ secrets.OCTOKIT_APP_PRIVATE_KEY }}
       - name: create pull request
         uses: gr2m/create-or-update-pull-request-action@v1.x
         env:
-          GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           title: 🚧 🤖📯 GraphQL Schema changed
           body: >


### PR DESCRIPTION
This should resolve the failing `Update` workflow builds: https://github.com/octokit/graphql-schema/actions/workflows/update.yml

<img width="862" alt="image" src="https://github.com/user-attachments/assets/92aa1892-8a3a-4a5d-8641-22901d9d35c0" />
